### PR TITLE
Does not perform 'deploy:pending:log' at the first time to deploy.

### DIFF
--- a/lib/capistrano/pending/tasks/pending.rake
+++ b/lib/capistrano/pending/tasks/pending.rake
@@ -5,7 +5,13 @@ namespace :deploy do
     of the changes that have occurred since the last deploy. Note that this \
     might not be supported on all SCM's
   DESC
-  task :pending => "deploy:pending:log"
+  task :pending do
+    on roles fetch(:capistrano_pending_role, :db) do |host|
+      if test "[ -f #{current_path}/REVISION ]"
+        invoke "deploy:pending:log"
+      end
+    end
+  end
 
   namespace :pending do
     def _scm


### PR DESCRIPTION
At the first time to deploy with capistrano-pending, 'deploy:pending:log' tries to get the revision of an application already been deployed but it will fails. 

The failure is caused by the assumption of `capistrano-pending`, an application has been already deployed without `capistrano-pending` before. 

The first deploy would work if this pull request was merged :sushi: 
