### PR TITLE
Use constant detection to check for SCM type

### DIFF
--- a/lib/capistrano/pending/tasks/pending.rake
+++ b/lib/capistrano/pending/tasks/pending.rake
@@ -8,15 +8,17 @@ namespace :deploy do
   task :pending => "deploy:pending:log"
 
   namespace :pending do
-    def _scm
-      assumed_scm =
-        if defined?(Capistrano::SCM::Svn)
-          "svn"
-        elsif defined?(Capistrano::SCM::Git)
-          "git"
-        end
+    def _detect_scm
+      if defined?(Capistrano::SCM::Git)
+        "git"
+      elsif defined?(Capistrano::SCM::Svn)
+        "svn"
+      end
+    end
 
-      Capistrano::Pending::SCM.load(fetch(:scm, assumed_scm))
+    def _scm
+      scm = fetch(:scm, _detect_scm)
+      Capistrano::Pending::SCM.load(scm)
     end
 
     def _log(from, to)

--- a/lib/capistrano/pending/tasks/pending.rake
+++ b/lib/capistrano/pending/tasks/pending.rake
@@ -9,7 +9,14 @@ namespace :deploy do
 
   namespace :pending do
     def _scm
-      Capistrano::Pending::SCM.load(fetch(:scm))
+      assumed_scm =
+        if defined?(Capistrano::SCM::Svn)
+          "svn"
+        elsif defined?(Capistrano::SCM::Git)
+          "git"
+        end
+
+      Capistrano::Pending::SCM.load(fetch(:scm, assumed_scm))
     end
 
     def _log(from, to)


### PR DESCRIPTION
Continues to use the variable `:scm` if available. But in Capistrano 3.7, `:scm` is removed and pending no longer functions. Here we fall back to detecting if the constants for Git or Svn is defined and assume that SCM.

Hopefully this can resolve #7.